### PR TITLE
Avoid nginx startup failure

### DIFF
--- a/conf.d/default.conf
+++ b/conf.d/default.conf
@@ -8,6 +8,9 @@ server {
   root /var/www/html;
   index index.php index.html index.htm;
 
+  # Initialize the variable that specified to skip the cache
+  set $skip_cache 0;
+
   location / {
     try_files $uri $uri/ =404;
   }

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ Before going any further, you'll want to check their sites to ensure you're down
 * [zlib](https://www.zlib.net/)
 ```
 cd /usr/src/
-sudo wget http://nginx.org/download/nginx-1.15.0.tar.gz && sudo tar -xzvf nginx-1.15.0.tar.gz
+sudo wget http://nginx.org/download/nginx-1.15.1.tar.gz && sudo tar -xzvf nginx-1.15.1.tar.gz
 sudo wget https://github.com/openresty/headers-more-nginx-module/archive/v0.33.tar.gz && sudo tar -xzf v0.33.tar.gz
 sudo wget http://labs.frickle.com/files/ngx_cache_purge-2.3.tar.gz && sudo tar -xzf ngx_cache_purge-2.3.tar.gz
 sudo wget https://www.openssl.org/source/openssl-1.1.0h.tar.gz && sudo tar -xzf openssl-1.1.0h.tar.gz


### PR DESCRIPTION
If the skip_cache variable is not set in the default config the following occurs. Using Nginx nginx-1.15.1 source.
nginx: [emerg] unknown "skip_cache" variable
nginx: configuration file /etc/nginx/nginx.conf test failed